### PR TITLE
fix calculating wrong limit

### DIFF
--- a/scissors/src/main/java/com/lyft/android/scissors/TouchManager.java
+++ b/scissors/src/main/java/com/lyft/android/scissors/TouchManager.java
@@ -88,8 +88,8 @@ class TouchManager {
         this.bitmapWidth = bitmapWidth;
         this.bitmapHeight = bitmapHeight;
 
-        horizontalLimit = computeLimit(bitmapWidth, viewportWidth);
-        verticalLimit = computeLimit(bitmapHeight, viewportHeight);
+        horizontalLimit = computeLimit((int) (bitmapWidth * scale), viewportWidth);
+        verticalLimit = computeLimit((int) (bitmapHeight * scale), viewportHeight);
     }
 
     public int getViewportWidth() {


### PR DESCRIPTION
There are wrong limit calculating in method TouchManager.resetFor() because it doesn't use changed scale factor
