### PR TITLE
Fix #2: scaling and snapping issue when bitmap directly set.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 Change Log
 ==========
 
+Bugfix Issue #2 *(2016-01-14)*
+----------------------------
+
+Fixes #2
+Minimum scale never properly set when calling com.lyft.android.scissors.TouchManager.resetFor(...)
+Details:
+- setMinimumScale(...) in resetFor() prematurely called before this.bitmapWidth/Height were set.
+- computeLimit(...) in resetFor() called without proper scaling.
+- setMinimumScale(...) method was erroneously always set to 1.0f, when bitmap was smaller than viewport.
+
+
 Version 1.0.1 *(2015-11-19)*
 ----------------------------
 

--- a/scissors/src/main/java/com/lyft/android/scissors/TouchManager.java
+++ b/scissors/src/main/java/com/lyft/android/scissors/TouchManager.java
@@ -83,13 +83,13 @@ class TouchManager {
 
         imageBounds = new Rect(0, 0, availableWidth / 2, availableHeight / 2);
         setViewport(availableWidth);
-        setMinimumScale();
 
         this.bitmapWidth = bitmapWidth;
         this.bitmapHeight = bitmapHeight;
+        setMinimumScale();
 
-        horizontalLimit = computeLimit(bitmapWidth, viewportWidth);
-        verticalLimit = computeLimit(bitmapHeight, viewportHeight);
+        horizontalLimit = computeLimit((int) (bitmapWidth * minimumScale), viewportWidth);
+        verticalLimit = computeLimit((int) (bitmapHeight * minimumScale), viewportHeight);
     }
 
     public int getViewportWidth() {
@@ -173,10 +173,7 @@ class TouchManager {
     private void setMinimumScale() {
         float imageAspect = (float) bitmapWidth / bitmapHeight;
         float viewportAspect = (float) viewportWidth / viewportHeight;
-
-        if (bitmapWidth < viewportWidth || bitmapHeight < viewportHeight) {
-            minimumScale = 1f;
-        } else if (imageAspect > viewportAspect) {
+        if (imageAspect > viewportAspect) {
             minimumScale = (float) viewportHeight / bitmapHeight;
         } else {
             minimumScale = (float) viewportWidth / bitmapWidth;

--- a/scissors/src/test/java/com/lyft/android/scissors/TouchManagerScaleTest.java
+++ b/scissors/src/test/java/com/lyft/android/scissors/TouchManagerScaleTest.java
@@ -1,0 +1,68 @@
+package com.lyft.android.scissors;
+
+import android.graphics.Matrix;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.ParameterizedRobolectricTestRunner;
+import org.robolectric.annotation.Config;
+import org.robolectric.shadows.ShadowMatrix;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.robolectric.Shadows.shadowOf;
+
+@RunWith(ParameterizedRobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
+public class TouchManagerScaleTest {
+
+    private static final int MAX_TOUCH_POINTS = 2;
+
+    @ParameterizedRobolectricTestRunner.Parameters(name = "testCase {index}")
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+                {100, 200, 100, 200, 1f}, // no scaling perfect match
+                {100, 100, 200, 200, 2f}, // scale up matching aspect ratio
+                {100, 100, 50, 50, 0.5f}, // scale down matching bitmap ratio
+                {100, 110, 200, 200, 2f}, // scale up wide bitmap ratio
+                {100, 110, 50, 50, 0.5f}, // scale down wide bitmap ratio
+                {110, 100, 200, 200, 2f}, // scale up narrow bitmap ratio
+                {110, 100, 50, 50, 0.5f} // scale down narrow bitmap ratio
+        });
+    }
+
+    final int bitmapWidth;
+    final int bitmapHeight;
+    final int viewportWidth;
+    final int viewportHeight;
+    final float expectedScale;
+
+    public TouchManagerScaleTest(int bitmapWidth, int bitmapHeight, int viewportWidth, int viewportHeight, float expectedScale) {
+        this.bitmapWidth = bitmapWidth;
+        this.bitmapHeight = bitmapHeight;
+        this.viewportWidth = viewportWidth;
+        this.viewportHeight = viewportHeight;
+        this.expectedScale = expectedScale;
+    }
+
+    @Test
+    public void testTouchManagerScale() {
+        TouchManager touchManager = new TouchManager(MAX_TOUCH_POINTS, new CropViewConfig());
+        Matrix matrix = new Matrix();
+        String expected = ShadowMatrix.SCALE + " " + expectedScale + " " + expectedScale;
+        touchManager.resetFor(bitmapWidth, bitmapHeight, viewportWidth, viewportHeight);
+        touchManager.applyPositioningAndScale(matrix);
+        List<String> postOps = shadowOf(matrix).getPostOperations();
+        if (postOps == null || postOps.size() != 3) {
+            fail("postOps should be called exactly 3 times, was called "
+                    + (postOps == null ? 0 : postOps.size()) + " times");
+        }
+        String operation = postOps.get(1);
+        assertThat(operation).isEqualTo(expected);
+    }
+
+}


### PR DESCRIPTION
Fixes #2
Fix scaling and snapping issue when bitmap is smaller than viewport and
directly set (without extensions) into the CropView.
