### PR TITLE
Add badge for android-gems.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Android Gems](http://www.android-gems.com/badge/lyft/scissors.svg?branch=master)](http://www.android-gems.com/lib/lyft/scissors)
+
 <img src="art/scissors.png" width="256" align="right" hspace="20" />
 
 Scissors


### PR DESCRIPTION
Added badge for android-gems: http://www.android-gems.com/lib/lyft/scissors , it looks like this:

[![Android Gems](http://www.android-gems.com/badge/lyft/scissors.svg?branch=master)](http://www.android-gems.com/lib/lyft/scissors)
