### PR TITLE
Update build, close streams in case of exception

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ language: android
 android:
   components:
     - tools
-    - build-tools-23.0.2
-    - android-22
+    - build-tools-23.0.3
+    - android-23
     - extra-android-m2repository
 
 jdk:

--- a/build.gradle
+++ b/build.gradle
@@ -4,12 +4,11 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0'
+        classpath 'com.android.tools.build:gradle:2.1.0'
     }
 }
 
 allprojects {
-
     repositories {
         mavenCentral()
     }
@@ -17,14 +16,14 @@ allprojects {
 
 ext {
     minSdkVersion = 14
-    compileSdkVersion = 22
-    buildToolsVersion = '23.0.2'
+    compileSdkVersion = 23
+    buildToolsVersion = '23.0.3'
 
     junitVersion = '4.12'
     mockitoVersion = '1.10.19'
     robolectricVersion = '3.0'
     assertjVersion = '1.7.1'
-    supportVersion = '22.2.1'
+    supportVersion = '23.4.0'
 
     ci = 'true'.equals(System.getenv('CI'))
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.12-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.13-all.zip

--- a/scissors/build.gradle
+++ b/scissors/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     // Picasso
     provided 'com.squareup.picasso:picasso:[2.4.0, 2.5.2)'
     // Glide
-    provided 'com.github.bumptech.glide:glide:[3.5.0, 3.6.1)'
+    provided 'com.github.bumptech.glide:glide:[3.5.0, 3.7.0)'
     provided 'com.nostra13.universalimageloader:universal-image-loader:[1.9.2, 1.9.5)'
     provided 'com.android.support:support-v4:' + rootProject.ext.supportVersion
 }


### PR DESCRIPTION
- Add support for Glide 3.7.0
- Update to Android Gradle Plugin 2.1.0
- Use Support Library 23.4.0
- Use Compile SDK 23
- Use Build Tools 23.0.3
- Use Gradle 2.13
