### PR TITLE
Issue #33 Support cropping based on original image size

### DIFF
--- a/scissors-sample/src/main/java/com/lyft/android/scissorssample/MainActivity.java
+++ b/scissors-sample/src/main/java/com/lyft/android/scissorssample/MainActivity.java
@@ -118,6 +118,8 @@ public class MainActivity extends Activity {
                 .crop()
                 .quality(100)
                 .format(JPEG)
+                //.originalSize()
+                //.outputSize(320, 320)
                 .into(croppedFile))
                 .subscribeOn(io())
                 .observeOn(mainThread());

--- a/scissors/src/main/java/com/lyft/android/scissors/CropView.java
+++ b/scissors/src/main/java/com/lyft/android/scissors/CropView.java
@@ -213,6 +213,18 @@ public class CropView extends ImageView {
      */
     @Nullable
     public Bitmap crop() {
+        return crop(1.0f);
+    }
+
+    /**
+     * Performs synchronous image cropping based on configuration.
+     *
+     * @param outputScale multiplied with viewport size for calculating bitmap size.
+     * @return A {@link Bitmap} cropped based on viewport and user panning and zooming or <code>null</code> if no {@link Bitmap} has been
+     * provided.
+     */
+    @Nullable
+    public Bitmap crop(float outputScale) {
         if (bitmap == null) {
             return null;
         }
@@ -223,16 +235,31 @@ public class CropView extends ImageView {
         final int viewportHeight = touchManager.getViewportHeight();
         final int viewportWidth = touchManager.getViewportWidth();
 
-        final Bitmap dst = Bitmap.createBitmap(viewportWidth, viewportHeight, config);
+        final Bitmap dst = Bitmap.createBitmap((int)(viewportWidth * outputScale), (int)(viewportHeight * outputScale), config);
 
         Canvas canvas = new Canvas(dst);
         final int left = (getRight() - viewportWidth) / 2;
         final int top = (getBottom() - viewportHeight) / 2;
-        canvas.translate(-left, -top);
+        canvas.translate(-left * outputScale, -top * outputScale);
 
-        drawBitmap(canvas);
+        Matrix transform = new Matrix();
+        touchManager.applyPositioningAndScale(transform);
+        transform.postScale(outputScale, outputScale);
+
+        canvas.drawBitmap(bitmap, transform, bitmapPaint);
 
         return dst;
+    }
+
+    float calculateOutputScale(int width, int height) {
+        final float viewportHeight = touchManager.getViewportHeight();
+        final float viewportWidth = touchManager.getViewportWidth();
+
+        if (width / (float)height > viewportWidth / viewportHeight) {
+            return height / viewportHeight; //fit to height
+        } else {
+            return  width / viewportWidth; //fit to width
+        }
     }
 
     /**


### PR DESCRIPTION
https://github.com/lyft/scissors/issues/33

How to crop based on specified output bitmap size:
ex) 320 x 320px

``` java
cropView.extensions()
    .crop()
    .outputSize(320, 320)
    .into(croppedFile);
```

How to crop based on original image size:

``` java
cropView.extensions()
    .crop()
    .originalSize()
    .into(croppedFile);
```
