### PR TITLE
Allow explicity specifying which BitmapLoader to use

### DIFF
--- a/scissors-sample/src/main/java/com/lyft/android/scissorssample/MainActivity.java
+++ b/scissors-sample/src/main/java/com/lyft/android/scissorssample/MainActivity.java
@@ -28,20 +28,18 @@ import android.os.Bundle;
 import android.view.MotionEvent;
 import android.view.View;
 import android.widget.Toast;
-
-import com.lyft.android.scissors.CropView;
-import com.squareup.leakcanary.RefWatcher;
-
-import java.io.File;
-import java.util.List;
-
 import butterknife.Bind;
 import butterknife.ButterKnife;
 import butterknife.OnClick;
 import butterknife.OnTouch;
+import com.lyft.android.scissors.CropView;
+import com.squareup.leakcanary.RefWatcher;
 import rx.Observable;
 import rx.functions.Action1;
 import rx.subscriptions.CompositeSubscription;
+
+import java.io.File;
+import java.util.List;
 
 import static android.graphics.Bitmap.CompressFormat.JPEG;
 import static rx.android.schedulers.AndroidSchedulers.mainThread;

--- a/scissors/src/main/java/com/lyft/android/scissors/CropView.java
+++ b/scissors/src/main/java/com/lyft/android/scissors/CropView.java
@@ -28,6 +28,7 @@ import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.support.annotation.DrawableRes;
+import android.support.annotation.IntDef;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.util.AttributeSet;
@@ -39,6 +40,8 @@ import com.lyft.android.scissors.CropViewExtensions.LoadRequest;
 
 import java.io.File;
 import java.io.OutputStream;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 
 /**
  * An {@link ImageView} with a fixed viewport and cropping capabilities.
@@ -299,6 +302,28 @@ public class CropView extends ImageView {
          */
         public LoadRequest using(@Nullable BitmapLoader bitmapLoader) {
             return new LoadRequest(cropView).using(bitmapLoader);
+        }
+
+        @IntDef({LOADER_INVALID, LOADER_PICASSO, LOADER_GLIDE, LOADER_UIL})
+        @Retention(RetentionPolicy.CLASS)
+        @interface ExtensionBitmapLoader{}
+
+        static final int LOADER_INVALID = -1;
+        public static final int LOADER_PICASSO = 0;
+        public static final int LOADER_GLIDE = 1;
+        public static final int LOADER_UIL = 2;
+
+      /**
+       * Load a {@link Bitmap} using a reference to a {@link BitmapLoader}, you must call {@link LoadRequest#load(Object)} afterwards.
+       *
+       * Please ensure that the library for the {@link BitmapLoader} you reference is available on the classpath.
+       *
+       * @param bitmapLoaderReference a reference to the {@link BitmapLoader} to use to load desired (@link Bitmap}
+       * @see PicassoBitmapLoader
+       * @see GlideBitmapLoader
+       */
+        public LoadRequest using(@ExtensionBitmapLoader int bitmapLoaderReference) {
+            return new LoadRequest(cropView).using(bitmapLoaderReference);
         }
 
         /**


### PR DESCRIPTION
  - There are currently 2 options for using an extension BitmapLoader
    1. Call CropView.extensions().load()
      - This will use whatever image library is available on the
	classpath, starting with Picasso, then Glide, then UIL
      - There can be circumstances where Picasso and Glide are both on the
	classpath, and Glide is the desired library, but Picasso will be
	used instead
    2. Call CropView.extensions().using(GlideBitmapLoader...).load()
      - This will explicitly use the GlideBitmapLoader but loses the
	defered creation of the BitmapLoader if the CropView hasn't been
	attached yet
      - This could be a problem because the size of the Bitmap in
	GlideBitmapLoader is set to CropView's width and height, which if
	it is 0 will cause all images to fail loading

  - This solution provides the best of both worlds; the ability to
    explicitly state which BitmapLoader should be used, and the defered
    creation of it until CropView is attached