### PR TITLE
add getter for transform matrix

### DIFF
--- a/scissors/src/main/java/com/lyft/android/scissors/CropView.java
+++ b/scissors/src/main/java/com/lyft/android/scissors/CropView.java
@@ -293,6 +293,14 @@ public class CropView extends ImageView {
     }
 
     /**
+     * Get the transform matrix
+     * @return
+     */
+    public Matrix getTransformMatrix() {
+        return transform;
+    }
+
+    /**
      * Optional extensions to perform common actions involving a {@link CropView}
      */
     public static class Extensions {


### PR DESCRIPTION
Exposing the transform matrix. This will allow developers to get useful information about scaling, top, and left bitmap positioning.

Should be useful for #55 and #32 