### PR TITLE
Add support for Picasso 2.71828 and up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+Version 2.0.0 *(2018-11-20)*
+----------------------------
+- Add support for Picasso beyond version 2.5.2
+
 Version 1.1.2 *(2017-03-28)*
 ----------------------------
 - Add support for oval overlay

--- a/scissors2/build.gradle
+++ b/scissors2/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     compile 'com.android.support:support-annotations:' + rootProject.ext.supportVersion
     // Optional dependencies for extensions
     // Picasso
-    provided 'com.squareup.picasso:picasso:[2.4.0, 2.5.2)'
+    provided 'com.squareup.picasso:picasso:[2.4.0, 2.71828)'
     // Glide
     provided 'com.github.bumptech.glide:glide:4.1.1'
     provided 'com.nostra13.universalimageloader:universal-image-loader:[1.9.2, 1.9.5)'


### PR DESCRIPTION
In the latest Picasso release there is no more Picasso.with(Context context) method.
Instead there is a Picasso.get() method. Using reflection to call whatever method of
these two is available will enable scissors to work with both old style and new style
Picasso library.